### PR TITLE
Problem: OBS builds this only package against non-default libzmq

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -167,6 +167,10 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         CONFIG_OPTS+=("CPP=${CPP}")
     fi
 
+    if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
+        CONFIG_OPTS+=("--enable-address-sanitizer=yes")
+    fi
+
     # Clone and build dependencies, if not yet installed to Travis env as DEBs
     # or MacOS packages; other OSes are not currently supported by Travis cloud
     [ -z "$CI_TIME" ] || echo "`date`: Starting build of dependencies (if any)..."

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
 # Code coverage
+AC_MSG_CHECKING([whether to enable GCov])
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting])],
                   [FTY_METRIC_CACHE_GCOV="$withval"])
@@ -64,8 +65,27 @@ if test "x${FTY_METRIC_CACHE_GCOV}" == "xyes"; then
         CFLAGS="${CFLAGS} ${FTY_METRIC_CACHE_ORIG_CFLAGS}"
     fi
     AM_CONDITIONAL(WITH_GCOV, true)
+    AC_MSG_RESULT([yes])
 else
     AM_CONDITIONAL(WITH_GCOV, false)
+    AC_MSG_RESULT([no])
+fi
+
+# Memory mis-use detection
+AC_MSG_CHECKING([whether to enable ASan])
+AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
+                  [Build with GCC Address Sanitizer instrumentation])],
+                  [FTY_METRIC_CACHE_ASAN="$enableval"])
+
+if test "x${FTY_METRIC_CACHE_ASAN}" == "xyes"; then
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+
+    AM_CONDITIONAL(ENABLE_ASAN, true)
+    AC_MSG_RESULT([yes])
+else
+    AM_CONDITIONAL(ENABLE_ASAN, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Set pkgconfigdir

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -24,7 +24,7 @@ Maintainer:     fty-metric-cache Developers <eatonipcopensource@eaton.com>
 Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    libzmq5-dev,
+    libzmq3-dev,
     libczmq-dev,
     libmlm-dev,
     libfty-proto-dev,
@@ -43,7 +43,7 @@ Package: libfty-metric-cache-dev
 Architecture: any
 Section: libdevel
 Depends:
-    libzmq5-dev,
+    libzmq3-dev,
     libczmq-dev,
     libmlm-dev,
     libfty-proto-dev,


### PR DESCRIPTION
Solution: Regenerate with recent zproject (add asan/gcov and fix libzmq dependency version) for now; we'll switch to another common zmq/czmq set when all components are ready for this.