### PR TITLE
Problem : GET request doesn't manage regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,18 @@ where
 The USER peer sends the following message using MAILBOX SEND to
 FTY-METRIC-CACHE-SERVER ("fty-metric-cache") peer:
 
-* zuuid/GET/element - request current metrics for asset 'element'
+* zuuid/GET/element/[filter] - request current metrics for asset 'element'
 
 where
 * '/' indicates a multipart string message
-* 'element' MUST be name of existing asset
+* 'element' MUST be name of existing asset or a regex about asset name 
+* 'filter' is an optional parameter which filter as a regex type of metric
 * subject of the message MUST be "latest-rt-data".
 
 The FTY-METRIC-CACHE-SERVER peer MUST respond with this  message back to USER
 peer using MAILBOX SEND.
 
-* zuuid/OK/GET/metric-1/.../metric-n
+* zuuid/OK/GET/element/metric-1/.../metric-n
 
 where
 * '/' indicates a multipart frame message

--- a/src/fty_metric_cache_classes.h
+++ b/src/fty_metric_cache_classes.h
@@ -45,6 +45,9 @@ typedef struct _actor_commands_t actor_commands_t;
 #endif
 #ifndef RT_T_DEFINED
 typedef struct _rt_t rt_t;
+struct _rt_t {
+    zhashx_t *devices;      // hash of hashes ("device name", ("measurement", fty_proto_t*))
+};
 #define RT_T_DEFINED
 #endif
 #ifndef MAILBOX_T_DEFINED

--- a/src/fty_metric_cache_cli.c
+++ b/src/fty_metric_cache_cli.c
@@ -32,7 +32,7 @@
 const char *endpoint = "ipc://@/malamute";
 zpoller_t *poller = NULL;
 
-void print_device(const char *device, const char* filter,mlm_client_t *cli){
+void print_device(const char *device, const char* filter, mlm_client_t *cli){
     zmsg_t *send = zmsg_new ();
     zmsg_addstr (send, "");
     zmsg_addstr (send, "GET");

--- a/src/fty_metric_cache_cli.c
+++ b/src/fty_metric_cache_cli.c
@@ -32,11 +32,14 @@
 const char *endpoint = "ipc://@/malamute";
 zpoller_t *poller = NULL;
 
-void print_device(const char *device, mlm_client_t *cli){
+void print_device(const char *device, const char* filter,mlm_client_t *cli){
     zmsg_t *send = zmsg_new ();
     zmsg_addstr (send, "");
     zmsg_addstr (send, "GET");
     zmsg_addstr (send, device);
+    if(NULL!=filter){
+        zmsg_addstr (send, filter);
+    }
 
     int rv = mlm_client_sendto (cli, FTY_METRIC_CACHE_MAILBOX, RFC_RT_DATA_SUBJECT, NULL, 5000, &send);
     assert (rv == 0);
@@ -90,10 +93,12 @@ int main (int argc, char *argv [])
              || streq (argv [argn], "-h"))
         {
             puts ("agent-rt-cli [options]");
-            puts ("agent-rt-cli [device]    print all information about the device");
-            puts ("  --list / -l            print list of devices known to the agent");
-            puts ("  --verbose / -v         verbose output");
-            puts ("  --help / -h            this information");
+            puts ("agent-rt-cli device [filter] print all information about the device");
+            puts ("             device          device name or a regex");
+            puts ("             [filter]        regex filter to select specific metric name");
+            puts ("  --list / -l                print list of devices known to the agent");
+            puts ("  --verbose / -v             verbose output");
+            puts ("  --help / -h                this information");
             break;
         }
         else
@@ -110,7 +115,8 @@ int main (int argc, char *argv [])
             break;
         }
         else {
-            print_device(argv [argn], client);
+            char* filter=(argn==(argc-2))?argv[argn+1]:NULL;
+            print_device(argv [argn], filter, client);
             break;
         }
     }

--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -52,6 +52,9 @@ static void dump_hash_of_metrics(zhashx_t *hash, zmsg_t *reply,char *filter){
             metric = (fty_proto_t *) zhashx_next (hash);
         }
     }
+    if(NULL!=rex){
+        zrex_destroy(&rex);
+    }
 }
 
 //  --------------------------------------------------------------------------
@@ -142,7 +145,7 @@ mailbox_perform (mlm_client_t *client, zmsg_t **msg_p, rt_t *data)
                 //loop on device list
                 while (device) {
                     char* device_name=(char *) zhashx_cursor (data->devices);
-                    zlist_append(device_name_lst,(void*)device_name);
+                    zlist_push(device_name_lst,(void*)device_name);
                     device = (zhashx_t *) zhashx_next (data->devices);
                 }
                 char*device_name = (char *) zlist_first (device_name_lst);

--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -29,6 +29,31 @@
 #include "fty_metric_cache_classes.h"
 
 #define ENDPOINT "ipc://@/malamute"
+static void dump_hash_of_metrics(zhashx_t *hash, zmsg_t *reply,char *filter){
+    uint64_t now_s = time(NULL);
+    zrex_t *rex=NULL;
+    if(filter!=NULL){
+         rex = zrex_new (filter);
+         if(!zrex_valid(rex)){
+             zrex_destroy(&rex);
+             rex=NULL;
+         }
+    }
+    if (hash) {
+        fty_proto_t *metric = (fty_proto_t *) zhashx_first (hash);
+        while (metric) {
+            if ( fty_proto_time(metric) + fty_proto_ttl(metric) > now_s ) {
+                if(NULL==rex || zrex_matches(rex,fty_proto_type(metric))){
+                    fty_proto_t *copy = fty_proto_dup (metric);
+                    zmsg_t *encoded = fty_proto_encode (&copy);
+                    zmsg_addmsg (reply, &encoded);
+                }
+            }
+            metric = (fty_proto_t *) zhashx_next (hash);
+        }
+    }
+}
+
 //  --------------------------------------------------------------------------
 //  Perform mailbox deliver protocol
 void
@@ -37,7 +62,7 @@ mailbox_perform (mlm_client_t *client, zmsg_t **msg_p, rt_t *data)
     assert (client);
     assert (msg_p);
     assert (data);
-
+    
     if (!*msg_p)
         return;
     zmsg_t *msg = *msg_p;
@@ -99,26 +124,42 @@ mailbox_perform (mlm_client_t *client, zmsg_t **msg_p, rt_t *data)
                     mlm_client_sender (client), mlm_client_subject (client));
             return;
         }
+        //echk optional filter
+        char *filter=zmsg_popstr(msg);
         zmsg_t *reply = zmsg_new ();
         zmsg_addstr (reply, uuid);
         zmsg_addstr (reply, "OK");
         zmsg_addstr (reply, element);
-
         zhashx_t *hash = rt_get_element (data, element);
-        uint64_t now_s = time(NULL);
-        if (hash) {
-            fty_proto_t *metric = (fty_proto_t *) zhashx_first (hash);
-            while (metric) {
-                if ( fty_proto_time(metric) + fty_proto_ttl(metric) > now_s ) {
-                    fty_proto_t *copy = fty_proto_dup (metric);
-                    zmsg_t *encoded = fty_proto_encode (&copy);
-                    zmsg_addmsg (reply, &encoded);
+        if(hash!=NULL){
+            dump_hash_of_metrics(hash,reply,filter);
+        }else{
+            //trying to process element as a regex ..
+            zrex_t *rex = zrex_new (element);
+            if(zrex_valid(rex)){
+                zlist_t* device_name_lst=zlist_new();
+                zhashx_t *device = (zhashx_t *) zhashx_first (data->devices);
+                //loop on device list
+                while (device) {
+                    char* device_name=(char *) zhashx_cursor (data->devices);
+                    zlist_append(device_name_lst,(void*)device_name);
+                    device = (zhashx_t *) zhashx_next (data->devices);
                 }
-                metric = (fty_proto_t *) zhashx_next (hash);
+                char*device_name = (char *) zlist_first (device_name_lst);
+                //loop on device_name list
+                while (device_name) {
+                    if(zrex_matches(rex,device_name)){
+                        //regex match !
+                        dump_hash_of_metrics(rt_get_element (data, device_name),reply,filter);
+                    }
+                    device_name = (char *) zlist_next (device_name_lst);
+                }
+                zlist_destroy(&device_name_lst);
             }
+            zrex_destroy(&rex);
         }
-
         zstr_free (&element);
+        if(filter!=NULL)zstr_free (&filter);
 
         int rv = mlm_client_sendto (client, mlm_client_sender(client), RFC_RT_DATA_SUBJECT, NULL, 5000, &reply);
 

--- a/src/rt.c
+++ b/src/rt.c
@@ -30,9 +30,7 @@
 
 //  Structure of our class
 
-struct _rt_t {
-    zhashx_t *devices;      // hash of hashes ("device name", ("measurement", fty_proto_t*))
-};
+
 
 //  --------------------------------------------------------------------------
 //  Create a new rt
@@ -122,7 +120,7 @@ rt_get_element (rt_t *self, const char *element)
 {
     assert (self);
     assert (element);
-
+    
     return (zhashx_t *) zhashx_lookup (self->devices, element);
 }
 


### PR DESCRIPTION
Solution : GET request now support zuuid/GET/element/[filter]
where 
element is an asset name or a regular expression
filter is an optional regex about type of metric

Example 1: GET metrics about all racks
fty-metric-cache-cli 'rack-.*'

Example 2: GET only realpower.default metrics about all racks
fty-metric-cache-cli 'rack-.*' realpower.default$


Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>