### PR TITLE
Problem: no_config is not broken now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ bindings/qt/selftest/selftest
 nbproject/
 
 # configuration files AND their .in templates, as they are not used here
-# and the no_config flag in project.xml is broken
+# (Note: doubles for the no_config flag in project.xml just in case)
 src/fty-metric-cache.cfg.in
 src/fty-metric-cache.cfg
 


### PR DESCRIPTION
Solution: issue #32 reported that no_config handling is broken;
verified with current zproject code, and in fact it does not
generate nor package the *.cfg(.in) files for the main here.

Updated the comment in .gitignore to reflect this.
Left the ignore in place just in case, though :)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>